### PR TITLE
Fix file paths on Tetra

### DIFF
--- a/api/module.php
+++ b/api/module.php
@@ -46,7 +46,7 @@ class SSIDPool extends Module
 
       $this->streamFunction = function ()
       { 
-        $backupPath = "/sd/modules/SSIDPool/backups/";              
+        $backupPath = "/pineapple/modules/SSIDPool/backups/";              
         $log_list = array_reverse(glob($backupPath . "*"));
                                                                           
         echo '[';                                                         
@@ -102,7 +102,7 @@ class SSIDPool extends Module
     private function backupCurrent()
     {
       $ssidfile = "/etc/pineapple/ssid_file";
-      $destpath = "/sd/modules/SSIDPool/backups/";
+      $destpath = "/pineapple/modules/SSIDPool/backups/";
       $file = "ssid_" . time() . ".txt";
       mkdir($destpath);
       if (copy($ssidfile, $destpath . $file) == TRUE)


### PR DESCRIPTION
This module was producing errors on the Tetra due to lack of an SD card on that device. Changes here map file access through the main 'pineapple' path that will simlink to the SD card on the Nano if appropriate. 

Tested on Tetra and Nano.